### PR TITLE
Modularized gaussian noises' dtype.

### DIFF
--- a/tensorflow/python/keras/layers/noise.py
+++ b/tensorflow/python/keras/layers/noise.py
@@ -65,7 +65,9 @@ class GaussianNoise(Layer):
 
     def noised():
       return inputs + K.random_normal(
-          shape=array_ops.shape(inputs), mean=0., stddev=self.stddev)
+          shape=array_ops.shape(inputs), mean=0., stddev=self.stddev,
+          dtype=inputs.dtype
+      )
 
     return K.in_train_phase(noised, inputs, training=training)
 
@@ -115,7 +117,9 @@ class GaussianDropout(Layer):
       def noised():
         stddev = np.sqrt(self.rate / (1.0 - self.rate))
         return inputs * K.random_normal(
-            shape=array_ops.shape(inputs), mean=1.0, stddev=stddev)
+            shape=array_ops.shape(inputs), mean=1.0, stddev=stddev,
+            dtype=inputs.dtype
+        )
 
       return K.in_train_phase(noised, inputs, training=training)
     return inputs


### PR DESCRIPTION
As a reply to issue #30834, I propose this small fix that enforces the adjustment of gaussian noises' `dtype` with that of the inputs within `tf.keras.layers.GaussianNoise` and `tf.keras.layers.GaussianDropout`.